### PR TITLE
chore: Pin Docker image digests and add Dependabot docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: docker
+    directory: '/'
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 99
+    assignees:
+      - ffflorian
+    versioning-strategy: increase
   - package-ecosystem: npm
     directory: '/'
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:24-alpine
+FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
 
 # Set working directory
 WORKDIR /app
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl=8.17.0-r1
 
 # Copy needed files
 COPY . ./


### PR DESCRIPTION
## Summary
- pin Docker base images to current digests
- pin Dockerfile-installed packages where they are managed directly in the Dockerfile
- add or update Dependabot Docker configuration with monthly updates for @ffflorian
