### PR TITLE
ci: add Docker build test step after Dockerfile linting

### DIFF
--- a/.github/workflows/lint_test_publish.yml
+++ b/.github/workflows/lint_test_publish.yml
@@ -49,7 +49,6 @@ jobs:
 
   build_dockerfile:
     name: Build Docker image
-    needs: lint_dockerfile
     permissions:
       contents: read
     runs-on: ubuntu-latest
@@ -70,6 +69,7 @@ jobs:
   publish:
     name: Publish Release and Docker image
     needs:
+      - lint_dockerfile
       - build_dockerfile
       - lint_test_typescript
     permissions:

--- a/.github/workflows/lint_test_publish.yml
+++ b/.github/workflows/lint_test_publish.yml
@@ -47,10 +47,30 @@ jobs:
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
 
+  build_dockerfile:
+    name: Build Docker image
+    needs: lint_dockerfile
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
+
+      - name: Build Docker image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          push: false
+
   publish:
     name: Publish Release and Docker image
     needs:
-      - lint_dockerfile
+      - build_dockerfile
       - lint_test_typescript
     permissions:
       contents: write


### PR DESCRIPTION
## Summary

- Adds a `build_dockerfile` job that runs after `lint_dockerfile` to verify the Docker image can be built
- Uses `docker/setup-buildx-action@v4.1.0` and `docker/build-push-action@v7.2.0`, both pinned to commit SHAs
- The `publish` job now depends on `build_dockerfile` instead of `lint_dockerfile` directly, ensuring a successful build is required before publishing

## Test plan

- [ ] Verify the `build_dockerfile` job appears in CI and runs after `lint_dockerfile`
- [ ] Confirm the Docker image build completes without errors
- [ ] Confirm the `publish` job still runs correctly on `main` pushes

https://claude.ai/code/session_01JhUEFxLHqXDfYBnETPteyy

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhUEFxLHqXDfYBnETPteyy)_