### PR TITLE
ci: allow deploy job to run on manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/lint_test_publish.yml
+++ b/.github/workflows/lint_test_publish.yml
@@ -103,8 +103,10 @@ jobs:
     permissions:
       deployments: write
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (needs.publish.outputs.new_release_published == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main')
+      always() && (
+        github.event_name == 'workflow_dispatch' ||
+        (needs.publish.result == 'success' && needs.publish.outputs.new_release_published == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main')
+      )
     steps:
       - name: Deploy
         uses: ffflorian/actions/coolify-deploy@ab061ffdaad5753c96129a0784cc23e9f1b18350


### PR DESCRIPTION
## Summary

- The `deploy` job has `needs: publish`, but `publish` is skipped on `workflow_dispatch` (its `if` only allows `push` to `main`).
- GitHub propagates that skip to all dependents regardless of their own `if` condition, so `deploy` was always skipped on manual runs.
- Fix: add `always()` to `deploy`'s `if` to prevent the implicit skip, and guard the automated path with an explicit `needs.publish.result == 'success'` check.

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` and confirm the deploy job runs.
- [ ] Push a commit to `main` that produces a new release and confirm deploy still runs.
- [ ] Push a commit to `main` that does NOT produce a new release and confirm deploy is skipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_014cUwgv99dbKHsLHb9QKyx9)_