### PR TITLE
chore(deps): block only next major in Dependabot ignore rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     directory: /
     ignore:
       - dependency-name: node
-        versions:
-          - '> 26'
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 99
     package-ecosystem: docker
     schedule:
@@ -36,8 +36,8 @@ updates:
           - eslint-plugin-oxlint
     ignore:
       - dependency-name: '@types/node'
-        versions:
-          - '> 26'
+        update-types:
+          - version-update:semver-major
     open-pull-requests-limit: 99
     package-ecosystem: npm
     schedule:


### PR DESCRIPTION
Replace versions: ['> N'] ranges with update-types semver-major so minor/patch updates keep flowing while only the next major is held back.